### PR TITLE
Single Ended Input Example & README Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The Gain values determines the maximum positive voltage that can be measured whe
 Example: If the Gain is set to 2/3, the maximum positive voltage that can be measured is 6.144V.  
 *6.144/32768 = 0.0001875 V/level* . Let us call this value LSB size.  
 For different Gain values we will have different maximum measureable positive voltage(Full Scale Range) & its corresponding LSB size as shown in the table.  
+
 | Gain | Full Scale Range | LSB Size |
 | --- | --- | --- |
 | 2/3 | 6.144V | 0001875 = 187.5uV |

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ The Gain values determines the maximum positive voltage that can be measured whe
 Example: If the Gain is set to 2/3, the maximum positive voltage that can be measured is 6.144V.  
 *6.144/32768 = 0.0001875 V/level* . Let us call this value LSB size.  
 For different Gain values we will have different maximum measureable positive voltage(Full Scale Range) & its corresponding LSB size as shown in the table.  
-|Gain  |Full Scale Range  |LSB Size|
-|--|--|--|
-|2/3|6.144V|0001875 = 187.5uV|
-|1|4.096V|0.000125 = 125uV|
-|2|2.048V|0.0000625 = 62.5uV|
-|4|1.024V|0.00003125 = 31.25uV|
-|8|0.512V|0.000015625 = 15.625uV|
-|16|0.256V|0.0000078125 = 7.8216uV|
+| Gain | Full Scale Range | LSB Size |
+| --- | --- | --- |
+| 2/3 | 6.144V | 0001875 = 187.5uV |
+| 1 | 4.096V | 0.000125 = 125uV |
+| 2 | 2.048V | 0.0000625 = 62.5uV |
+| 4 | 1.024V | 0.00003125 = 31.25uV |
+| 8 | 0.512V |0.000015625 = 15.625uV |
+| 16 | 0.256V | 0.0000078125 = 7.8216uV |
 
 From this we can find the value of the Input Analog Voltage for these Gain values.  
 ***Input Analog Voltage =  Raw Value * LSB Size***

--- a/README.md
+++ b/README.md
@@ -16,3 +16,36 @@ Alternatively you can install from pip with:
     sudo pip install adafruit-ads1x15
 
 Note that the pip install method **won't** install the example code.
+
+## Analog Input Voltage Constraints
+Analog input voltages must never exceed the analog input voltage limits given in the Absolute Maximum Ratings. If a VDD supply voltage greater than 4 V is used, the ±6.144 V full-scale range allows input voltages to extend up to the supply. Although in this case (or whenever the supply voltage is less than the full-scale range; for example, VDD = 3.3 V and full-scale range = ±4.096 V), a full-scale ADC output code cannot be obtained. For example, with VDD = 3.3 V and FSR = ±4.096 V, only signals up to VIN = ±3.3 V can be measured. The code range that
+represents voltages |VIN| > 3.3 V is not used in this case.
+
+## Single Ended VS Differential Inputs
+The ADS1x15 breakouts support up to 4 Single Ended or 2 Differential inputs.
+Single Ended inputs measure the voltage between the analog input channel (A0-A3) and analog ground (GND).
+Differential inputs measure the voltage between two analog input channels.  (A0&A1 or A2&A3).
+
+Single Ended Inputs can only measure **Positive voltages**. Without the sign bit, you only get an
+effective **15 bit resolution**.
+Differential inputs can measure both **Positive and Negative voltages** providing the full **16 bit
+resolution**.
+
+## Single Ended Input Voltage Measurement
+Single Ended Inputs have a resolution of only 15 bits(2^15 = 32768 levels) and can measure only positive voltages.  
+The Gain values determines the maximum positive voltage that can be measured whereas the supply voltage is just the physical limit of the signal you can measure without damaging the chip.
+
+Example: If the Gain is set to 2/3, the maximum positive voltage that can be measured is 6.144V.  
+*6.144/32768 = 0.0001875 V/level* . Let us call this value LSB size.  
+For different Gain values we will have different maximum measureable positive voltage(Full Scale Range) & its corresponding LSB size as shown in the table.  
+|Gain  |Full Scale Range  |LSB Size|
+|--|--|--|
+|2/3|6.144V|0001875 = 187.5uV|
+|1|4.096V|0.000125 = 125uV|
+|2|2.048V|0.0000625 = 62.5uV|
+|4|1.024V|0.00003125 = 31.25uV|
+|8|0.512V|0.000015625 = 15.625uV|
+|16|0.256V|0.0000078125 = 7.8216uV|
+
+From this we can find the value of the Input Analog Voltage for these Gain values.  
+***Input Analog Voltage =  Raw Value * LSB Size***

--- a/examples/singleendinput.py
+++ b/examples/singleendinput.py
@@ -1,0 +1,43 @@
+# Simple demo of single ended conversion of channel 0 & its respective voltage value.
+# Author: Jonathan Pereira
+# License: Public Domain
+import time
+
+# Import the ADS1x15 module.
+import Adafruit_ADS1x15
+
+
+# Create an ADS1115 ADC (15-bit) instance.
+adc = Adafruit_ADS1x15.ADS1115()
+
+# Or create an ADS1015 ADC (12-bit) instance.
+#adc = Adafruit_ADS1x15.ADS1015()
+
+# Note you can change the I2C address from its default (0x48), and/or the I2C
+# bus by passing in these optional parameters:
+#adc = Adafruit_ADS1x15.ADS1015(address=0x49, busnum=1)
+
+# Choose a gain of 1 for reading voltages from 0 to 4.09V.
+# Or pick a different gain to change the range of voltages that are read:
+#  - 2/3 = +6.144V
+#  -   1 = +4.096V
+#  -   2 = +2.048V
+#  -   4 = +1.024V
+#  -   8 = +0.512V
+#  -  16 = +0.256V
+# See table 3 in the ADS1015/ADS1115 datasheet for more info on gain.
+channel = 0 # ADC Channel set to 0.
+GAIN = 2/3
+LSB = 0.0001875
+
+#For Single Ended Conversion, the single ended inputs can, by definition,
+#only measure positive voltages. Without the sign bit, you only get an effective 15 bit resolution or 32768 levels.
+
+#Example: If the Gain is set to 2/3, the ADC can measure only a positive voltage,
+#ranging from 0V to 6.144V. Hence 1 level(raw value) = 0.0001875V.
+
+while  True:
+    raw_value = adc.read_adc(channel, gain=GAIN)
+    voltage = raw_value * LSB
+    print(raw_value)
+    print(voltage)


### PR DESCRIPTION
The changes are supported in Python 2.7 & 3. They have been tested on a Raspberry Pi 3.

**Single Ended Input Example**
The original examples considered a 16-bit resolution for Single Ended Inputs.
But according to the datasheet, 16-bit resolution applies only to Differential inputs whereas a 15-bit resolution applies to the Single Ended Inputs. I made an example which takes this into consideration and also calculates & prints the value of the Input Analog Voltage.

**README Update**
When I began using this library, I had various doubts regarding the Analog Input Voltage constraints, The differences between Single Ended & Differential Inputs and Calculation of Input Analog Voltage.

1.  I discussed the relationship between the Power Supply voltage which determines the Maximum Analog Input Voltage with an example.
2.  I defined the bit resolutions of Single and Differential Inputs & also their pin configurations.
3.  Provided a detailed explanation, formulas & reference tables to calculate the Input Analog Voltage for  Single Ended Input.